### PR TITLE
Switch to generate Swagger Docs automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ This is an open-source software free for anyone to use. I do NOT claim to own.
 ## Top Features
  - Automatic API data ingestion from data providers
  - CronJob scheduling
+ - Automatically generate API Documentation
 
 
 ## Integrations
  - MongoDB
  - Google Cloud
- - SwaggerUI
+ - SwaggerUI and [swagger-autogen](https://www.npmjs.com/package/swagger-autogen)
  - JetSetPedia
 
 
@@ -45,6 +46,7 @@ Feel free to post anything under Issues even if it is a question or comment. If 
 ## Acknowledgements
  - SEGA - Creators and Owners of Jet Set Radio
  - Hideki Naganuma - Composer, DJ, and Remixer of Jet Set Radio Music
+ - All other artists that contributed to the franchise
  - The Creators and Contributors of [JetSetPedia](https://jetsetradio.fandom.com/wiki/Main_Page)
  - Greg Kennedy for gathering all of the [JSR Graffiti Files](https://greg-kennedy.com/jsr/) into one organized place.
  - The JetSetRadio Community

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,49 +16,9 @@
         "express": "^4.18.2",
         "mongodb": "^5.1.0",
         "nodemon": "^2.0.22",
-        "swagger-jsdoc": "^6.2.8",
+        "swagger-autogen": "^2.23.1",
         "swagger-ui-express": "^4.6.2",
         "winston": "^3.8.2"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apidevtools/openapi-schemas": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
-    },
-    "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
-      },
-      "peerDependencies": {
-        "openapi-types": ">=7"
       }
     },
     "node_modules/@colors/colors": {
@@ -78,16 +38,6 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/node": {
       "version": "18.15.11",
@@ -130,6 +80,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -155,11 +116,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -270,11 +226,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -383,14 +334,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -448,6 +391,14 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -471,17 +422,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -528,14 +468,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -735,25 +667,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -924,36 +837,21 @@
         "node": ">=10"
       }
     },
-    "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
-    "node_modules/lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "node_modules/logform": {
       "version": "2.5.1",
@@ -1218,12 +1116,6 @@
       "dependencies": {
         "fn.name": "1.x.x"
       }
-    },
-    "node_modules/openapi-types": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
-      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
-      "peer": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -1552,34 +1444,34 @@
         "node": ">=8"
       }
     },
-    "node_modules/swagger-jsdoc": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+    "node_modules/swagger-autogen": {
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.1.tgz",
+      "integrity": "sha512-tOAb5cOGNPduIHKoOxndCRy2Mrg7xV3O1RerrWExrDxeSTjXhA350pyJd7VUDY6ZO9gbZ34Bjlc5CXkleUgvAQ==",
       "dependencies": {
-        "commander": "6.2.0",
-        "doctrine": "3.0.0",
-        "glob": "7.1.6",
-        "lodash.mergewith": "^4.6.2",
-        "swagger-parser": "^10.0.3",
-        "yaml": "2.0.0-1"
-      },
-      "bin": {
-        "swagger-jsdoc": "bin/swagger-jsdoc.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
       }
     },
-    "node_modules/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+    "node_modules/swagger-autogen/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
-        "@apidevtools/swagger-parser": "10.0.3"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/swagger-ui-dist": {
@@ -1690,14 +1582,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1764,79 +1648,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/yaml": {
-      "version": "2.0.0-1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
-      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^9.4.1"
-      }
-    },
-    "node_modules/z-schema/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
     }
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
-    "@apidevtools/openapi-schemas": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
-      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
-    },
-    "@apidevtools/swagger-methods": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
-      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
-    },
-    "@apidevtools/swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
-      "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
-        "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^5.0.1"
-      }
-    },
     "@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -1851,16 +1665,6 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
-    },
-    "@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
-    "@types/json-schema": {
-      "version": "7.0.11",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/node": {
       "version": "18.15.11",
@@ -1900,6 +1704,11 @@
         "negotiator": "0.6.3"
       }
     },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+    },
     "ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1916,11 +1725,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-flatten": {
       "version": "1.1.1",
@@ -2012,11 +1816,6 @@
         "get-intrinsic": "^1.0.2"
       }
     },
-    "call-me-maybe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2104,11 +1903,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2154,6 +1948,11 @@
         "ms": "2.0.0"
       }
     },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -2168,14 +1967,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
-    },
-    "doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "requires": {
-        "esutils": "^2.0.2"
-      }
     },
     "dotenv": {
       "version": "16.0.3",
@@ -2209,11 +2000,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -2367,19 +2153,6 @@
         "has-symbols": "^1.0.3"
       }
     },
-    "glob": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
     "glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2502,33 +2275,15 @@
         "minimatch": "^3.0.4"
       }
     },
-    "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "requires": {
-        "argparse": "^2.0.1"
-      }
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "logform": {
       "version": "2.5.1",
@@ -2718,12 +2473,6 @@
       "requires": {
         "fn.name": "1.x.x"
       }
-    },
-    "openapi-types": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.0.tgz",
-      "integrity": "sha512-XpeCy01X6L5EpP+6Hc3jWN7rMZJ+/k1lwki/kTmWzbVhdPie3jd5O2ZtedEx8Yp58icJ0osVldLMrTB/zslQXA==",
-      "peer": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -2965,25 +2714,30 @@
         "has-flag": "^4.0.0"
       }
     },
-    "swagger-jsdoc": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
-      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+    "swagger-autogen": {
+      "version": "2.23.1",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.1.tgz",
+      "integrity": "sha512-tOAb5cOGNPduIHKoOxndCRy2Mrg7xV3O1RerrWExrDxeSTjXhA350pyJd7VUDY6ZO9gbZ34Bjlc5CXkleUgvAQ==",
       "requires": {
-        "commander": "6.2.0",
-        "doctrine": "3.0.0",
-        "glob": "7.1.6",
-        "lodash.mergewith": "^4.6.2",
-        "swagger-parser": "^10.0.3",
-        "yaml": "2.0.0-1"
-      }
-    },
-    "swagger-parser": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
-      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
-      "requires": {
-        "@apidevtools/swagger-parser": "10.0.3"
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "swagger-ui-dist": {
@@ -3067,11 +2821,6 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
-    "validator": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
-      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3123,30 +2872,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "yaml": {
-      "version": "2.0.0-1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
-      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="
-    },
-    "z-schema": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
-      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
-      "requires": {
-        "commander": "^9.4.1",
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.7.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "9.5.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "src/app.js",
   "scripts": {
     "build": "npm install",
-    "prod": "export $(cat ./prod.env | egrep -v '#|^$' | xargs) && node src/app.js",
-    "qa": "export $(cat ./qa.env | egrep -v '#|^$' | xargs) && nodemon --inspect src/app.js"
+    "prod": "export $(cat ./prod.env | egrep -v '#|^$' | xargs) && node src/utils/swagger.js",
+    "qa": "export $(cat ./qa.env | egrep -v '#|^$' | xargs) && nodemon --inspect --ignore src/utils/ src/utils/swagger.js"
   },
   "keywords": [],
   "author": "RazzNBlue",
@@ -20,7 +20,7 @@
     "express": "^4.18.2",
     "mongodb": "^5.1.0",
     "nodemon": "^2.0.22",
-    "swagger-jsdoc": "^6.2.8",
+    "swagger-autogen": "^2.23.1",
     "swagger-ui-express": "^4.6.2",
     "winston": "^3.8.2"
   }

--- a/src/managers/MiddlewareManager.js
+++ b/src/managers/MiddlewareManager.js
@@ -2,10 +2,13 @@ import express from 'express';
 import { fileURLToPath } from 'url';
 import path, { dirname } from 'path';
 import cors from 'cors';
+import swaggerUi from 'swagger-ui-express';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const data = require('../utils/swagger-docs.json');
 
 import HealthCheckManager from './HealthCheckManager.js';
 import router from '../routes/router.js';
-import setUpSwagger from '../utils/swagger.js';
 import { renderHome } from '../controllers/indexController.js';
 
 
@@ -26,8 +29,7 @@ class MiddlewareManager {
     app.get('/', (req, res) => renderHome(req, res));
     app.get('/health', (req, res) => res.send(healthCheckManager.getAppHealth()));
     app.use('/v1/api', router);
-
-    setUpSwagger(app);
+    app.use('/docs', swaggerUi.serve, swaggerUi.setup(data))
   }
 
 }

--- a/src/routes/artistRouter.js
+++ b/src/routes/artistRouter.js
@@ -5,9 +5,8 @@ import { getArtists, getArtistById, getSongsByArtist } from '../controllers/arti
 
 const artists = express.Router();
 
-// Add game=jsr/jsrf query parameter on getArtists
-artists.get('/', async (req, res) => await getArtists(req, res));
-artists.get('/:id', async (req, res) => await getArtistById(req, res));
-artists.get('/:id/songs', async (req, res) => await getSongsByArtist(req, res));
+artists.get('/', async (req, res) => /* #swagger.tags = ['Artists'] */ await getArtists(req, res));
+artists.get('/:id', async (req, res) => /* #swagger.tags = ['Artists'] */ await getArtistById(req, res));
+artists.get('/:id/songs', async (req, res) => /* #swagger.tags = ['Artists'] */ await getSongsByArtist(req, res));
 
 export default artists;

--- a/src/routes/gameRouter.js
+++ b/src/routes/gameRouter.js
@@ -4,36 +4,7 @@ import { getAllGames, getGameById } from '../controllers/gameController.js ';
 
 const games = express.Router();
 
-/**
- * @openapi
- * /v1/api/games:
- *  get:
- *    tags: 
- *      - Games
- *    description: Games in the Jet Set Radio Franchise
- *    responses:
- *      200:
- *        description: Returning all Games
- */
-games.get('/', async (req, res) => await getAllGames(req, res));
-
-/**
- * @openapi
- * /v1/api/games/{gameId}:
- *  get:
- *    tags: 
- *      - Games
- *    description: A single Game by Id
- *    parameters:
- *      - in: path
- *        name: gameId
- *        type: string
- *        required: true
- *        description: Object ID of the game to get
- *    responses:
- *      200:
- *        description: Returning Game with given id
- */
-games.get('/:id', async (req, res) => await getGameById(req, res));
+games.get('/', async (req, res) => /* #swagger.tags = ['Games'] */ await getAllGames(req, res));
+games.get('/:id', async (req, res) => /* #swagger.tags = ['Games'] */ await getGameById(req, res));
 
 export default games;

--- a/src/routes/graffitiTagRouter.js
+++ b/src/routes/graffitiTagRouter.js
@@ -5,81 +5,10 @@ import { getAllGraffitiTags, getJSRGraffitiTagById, getJSRFGraffitiTagById,
 
 const graffitiTags = express.Router();
 
-/**
- * @openapi
- * /v1/api/graffiti-tags:
- *  get:
- *    tags: 
- *      - GraffitiTags
- *    description: All graffiti tags
- *    responses:
- *      200:
- *        description: Returning all graffiti-tags from JSRF and JSR
- */
-graffitiTags.get('/', async (req, res) => await getAllGraffitiTags(req, res));
-
-/**
- * @openapi
- * /v1/api/graffiti-tags/jsr:
- *  get:
- *    tags: 
- *      - GraffitiTags
- *    description: JSR graffiti tags
- *    responses:
- *      200:
- *        description: Returning only graffiti-tags from JSR
- */
-graffitiTags.get('/jsr', async (req, res) => await getJSRGraffitiTags(req, res));
-
-/**
- * @openapi
- * /v1/api/graffiti-tags/jsr/{tagId}:
- *  get:
- *    tags: 
- *      - GraffitiTags
- *    description: A single GraffitiTag by Id
- *    parameters:
- *      - in: path
- *        name: tagId
- *        type: string
- *        required: true
- *        description: Object ID of the GraffitiTag to get
- *    responses:
- *      200:
- *        description: Returning GraffitiTag with given id
- */
-graffitiTags.get('/jsr/:id', async (req, res) => await getJSRGraffitiTagById(req, res));
-
-/**
- * @openapi
- * /v1/api/graffiti-tags/jsrf:
- *  get:
- *    tags: 
- *      - GraffitiTags
- *    description: JSRF graffiti tags
- *    responses:
- *      200:
- *        description: Returning only graffiti-tags from JSRF
- */
-graffitiTags.get('/jsrf', async (req, res) => await getJSRFGraffitiTags(req, res));
-
-/**
- * @openapi
- * /v1/api/graffiti-tags/jsrf/{tagId}:
- *  get:
- *    tags: 
- *      - GraffitiTags
- *    description: A single GraffitiTag by Id
- *    parameters:
- *      - in: path
- *        name: tagId
- *        type: string
- *        required: true
- *        description: Object ID of the GraffitiTag to get
- *    responses:
- *      200:
- *        description: Returning GraffitiTag with given id
- */
-graffitiTags.get('/jsrf/:id', async (req, res) => await getJSRFGraffitiTagById(req, res));
+graffitiTags.get('/', async (req, res) => /* #swagger.tags = ['GraffitiTags'] */ await getAllGraffitiTags(req, res));
+graffitiTags.get('/jsr', async (req, res) => /* #swagger.tags = ['GraffitiTags'] */ await getJSRGraffitiTags(req, res));
+graffitiTags.get('/jsr/:id', async (req, res) => /* #swagger.tags = ['GraffitiTags'] */ await getJSRGraffitiTagById(req, res));
+graffitiTags.get('/jsrf', async (req, res) => /* #swagger.tags = ['GraffitiTags'] */ await getJSRFGraffitiTags(req, res));
+graffitiTags.get('/jsrf/:id', async (req, res) => /* #swagger.tags = ['GraffitiTags'] */ await getJSRFGraffitiTagById(req, res));
 
 export default graffitiTags;

--- a/src/routes/songRouter.js
+++ b/src/routes/songRouter.js
@@ -2,13 +2,13 @@ import express from 'express';
 
 import { getSongs, getJSRSongs, getJSRSongById, getJSRFSongs, getJSRFSongById } from '../controllers/songController.js';
 
+
 const songs = express.Router();
 
-// Add game=jsr/jsrf query parameter on getSongs
-songs.get('/', async (req, res) => await getSongs(req, res));
-songs.get('/jsr', async (req, res) => await getJSRSongs(req, res));
-songs.get('/jsr/:id', async (req, res) => await getJSRSongById(req, res));
-songs.get('/jsrf', async (req, res) => await getJSRFSongs(req, res));
-songs.get('/jsrf/:id', async (req, res) => await getJSRFSongById(req, res));
+songs.get('/', async (req, res) => /* #swagger.tags = ['Songs'] */ await getSongs(req, res));
+songs.get('/jsr', async (req, res) => /* #swagger.tags = ['Songs'] */ await getJSRSongs(req, res));
+songs.get('/jsr/:id', async (req, res) => /* #swagger.tags = ['Songs'] */ await getJSRSongById(req, res));
+songs.get('/jsrf', async (req, res) => /* #swagger.tags = ['Songs'] */ await getJSRFSongs(req, res));
+songs.get('/jsrf/:id', async (req, res) => /* #swagger.tags = ['Songs'] */ await getJSRFSongById(req, res));
 
 export default songs;

--- a/src/utils/swagger-docs.json
+++ b/src/utils/swagger-docs.json
@@ -1,0 +1,341 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "JetSetRadio-API",
+    "version": "1.0.0",
+    "description": "Providing data for all things JSR and JSRF!"
+  },
+  "host": "localhost:8080",
+  "basePath": "/v1/api/",
+  "tags": [
+    {
+      "name": "Games",
+      "description": "Title from the JetSetRadio Franchise"
+    },
+    {
+      "name": "GraffitiTags",
+      "description": "All Graffiti-Points from the games"
+    },
+    {
+      "name": "Songs",
+      "description": "Soundtrack Data from JSR and JSRF"
+    },
+    {
+      "name": "Artists",
+      "description": "Artist Data from JSR and JSRF"
+    }
+  ],
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "paths": {
+    "/games/": {
+      "get": {
+        "tags": [
+          "Games"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/games/{id}": {
+      "get": {
+        "tags": [
+          "Games"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/graffiti-tags/": {
+      "get": {
+        "tags": [
+          "GraffitiTags"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/graffiti-tags/jsr": {
+      "get": {
+        "tags": [
+          "GraffitiTags"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/graffiti-tags/jsr/{id}": {
+      "get": {
+        "tags": [
+          "GraffitiTags"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/graffiti-tags/jsrf": {
+      "get": {
+        "tags": [
+          "GraffitiTags"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/graffiti-tags/jsrf/{id}": {
+      "get": {
+        "tags": [
+          "GraffitiTags"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/songs/": {
+      "get": {
+        "tags": [
+          "Songs"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/songs/jsr": {
+      "get": {
+        "tags": [
+          "Songs"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/songs/jsr/{id}": {
+      "get": {
+        "tags": [
+          "Songs"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/songs/jsrf": {
+      "get": {
+        "tags": [
+          "Songs"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/songs/jsrf/{id}": {
+      "get": {
+        "tags": [
+          "Songs"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/artists/": {
+      "get": {
+        "tags": [
+          "Artists"
+        ],
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/artists/{id}": {
+      "get": {
+        "tags": [
+          "Artists"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/artists/{id}/songs": {
+      "get": {
+        "tags": [
+          "Artists"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/utils/swagger.js
+++ b/src/utils/swagger.js
@@ -1,34 +1,39 @@
-import swaggerJSDoc from 'swagger-jsdoc';
-import swaggerUi from 'swagger-ui-express';
-import LOGGER from './logger.js';
+import swaggerAutogen from "swagger-autogen";
+import dotenv from 'dotenv';
+dotenv.config();
 
-
-const options = {
-  definition: {
-    openapi: '3.0.0',
-    info: {
-      title: 'JetSetRadio-API',
-      version: process.env.npm_package_version,
-    },
+const doc = {
+  info: {
+    title: 'JetSetRadio-API',
+    version: process.env.npm_package_version,
+    description: 'Providing data for all things JSR and JSRF!',
   },
-  apis: ['./src/routes/gameRouter.js', './src/routes/graffitiTagRouter.js'],
+  host: process.env.BASE_URL.split('http://')[1],
+  schemes: ['http', 'https'],
+  basePath: '/v1/api/',
+  tags: [
+    {
+      "name": "Games",
+      "description": "Title from the JetSetRadio Franchise"
+    },
+    {
+      "name": "GraffitiTags",
+      "description": "All Graffiti-Points from the games"
+    },
+    {
+      "name": "Songs",
+      "description": "Soundtrack Data from JSR and JSRF"
+    },
+    {
+      "name": "Artists",
+      "description": "Artist Data from JSR and JSRF"
+    }
+],
 };
 
-const swaggerSpec = swaggerJSDoc(options);
+const outputFile = './src/utils/swagger-docs.json';
+const endpointFiles = ['./src/routes/router.js'];
 
-const setUpSwagger = (app) => {
-
-  const docsPath = '/api-docs';
-  // Swagger Page
-  app.use(docsPath, swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-
-  // Docs in JSON
-  app.get(`${docsPath}.json`, (req, res) => {
-    res.setHeader('Content-Type', 'application/json');
-    res.send(swaggerSpec);
-  });
-
-  LOGGER.info(`Docs available at ${process.env.BASE_URL}${docsPath}`);
-}
-
-export default setUpSwagger;
+swaggerAutogen()(outputFile, endpointFiles, doc).then(async () => {
+  await import('../app.js');
+})


### PR DESCRIPTION
Switch from using swagger-jsdoc to using [swagger-autogen](https://www.npmjs.com/package/swagger-autogen) to be able to generate documentation at run-time, instead of manually writing the @openapi docs for every single new route.