### PR TITLE
Add Sorting and Filtering to Requests

### DIFF
--- a/src/config/dbActions.js
+++ b/src/config/dbActions.js
@@ -2,7 +2,7 @@ import { ObjectId } from "mongodb";
 
 export const Actions = {
   getCollectionsList: async (client, dbName) => { return await client.db(dbName).collections },
-  fetchAll: async (client, dbName, collectionName, qps) => { return await client.db(dbName).collection(collectionName).find({}).toArray() },
-  fetchWithQuery: async (client, dbName, collectionName, id, qps) => { return await client.db(dbName).collection(collectionName).find(qps).toArray() },
+  fetchAll: async (client, dbName, collectionName, id, qps, sortValue) => { return await client.db(dbName).collection(collectionName).find({}).sort(sortValue).toArray() },
+  fetchWithQuery: async (client, dbName, collectionName, id, qps, queryActions) => { return await client.db(dbName).collection(collectionName).find(qps).sort(queryActions[0]).limit(queryActions[1]).toArray() },
   fetchById: async (client, dbName, collectionName, id) => { return await client.db(dbName).collection(collectionName).findOne({ _id: new ObjectId(id) }) },
 }

--- a/src/controllers/characterController.js
+++ b/src/controllers/characterController.js
@@ -1,14 +1,21 @@
 import { performJSRAction, performJSRFAction } from "../config/db.js";
 import { Actions } from "../config/dbActions.js";
 import LOGGER from "../utils/logger.js";
+import { sortObjects } from "../utils/utility.js";
 
 
 const Character = 'Character';
 
 export const getAllCharacters = async (req, res) => {
   try {
+    const sortByValue = req?.query?.sortBy ? req?.query?.sortBy : undefined;
+    const sortOrder = req?.query?.orderBy ? req?.query?.orderBy : 'asc';
     const jsrCharacters = await fetchJSRCharacters(req);
     const jsrfCharacters = await fetchJSRFCharacters(req);
+    if (sortByValue) {
+      const characters = [...jsrCharacters, ...jsrfCharacters];
+      return res.send(characters.sort(sortObjects(sortByValue, sortOrder)));
+    }
     res.send([...jsrCharacters, ...jsrfCharacters]);
   } catch(err) {
     LOGGER.error(`Could not fetch ALL Characters \n${err}`);
@@ -50,15 +57,9 @@ export const getJSRFCharacterById = async (req, res) => {
 }
 
 export const fetchJSRCharacters = async (req) => {
-  if (req?.query) {
-    return await performJSRAction(Actions.fetchWithQuery, Character, null, req?.query);
-  }
-  return await performJSRAction(Actions.fetchAll, Character, null);
+  return await performJSRAction(Actions.fetchWithQuery, Character, null, req?.query);
 }
 
 export const fetchJSRFCharacters = async (req) => {
-  if (req?.query) {
-    return await performJSRFAction(Actions.fetchWithQuery, Character, null, req?.query);
-  }
-  return await performJSRFAction(Actions.fetchAll, Character, null);
+  return await performJSRFAction(Actions.fetchWithQuery, Character, null, req?.query);
 }

--- a/src/controllers/gameController.js
+++ b/src/controllers/gameController.js
@@ -22,10 +22,7 @@ export const getGameById = async (req, res) => {
 
 
 export const fetchGames = async (query) => {
-  if (query) {
-    return await performCoreAction(Actions.fetchWithQuery, Game, null, query);
-  }
-  return await performCoreAction(Actions.fetchAll, Game, null);
+  return await performCoreAction(Actions.fetchWithQuery, Game, null, query);
 }
 
 export const fetchGameById = async (id) => {

--- a/src/controllers/graffitiTagController.js
+++ b/src/controllers/graffitiTagController.js
@@ -1,14 +1,21 @@
 import { performJSRAction, performJSRFAction } from "../config/db.js";
 import { Actions } from "../config/dbActions.js";
 import LOGGER from "../utils/logger.js";
+import { sortObjects } from "../utils/utility.js";
 
 
 const GraffitiTag = 'GraffitiTag';
 
 export const getAllGraffitiTags = async (req, res) => {
   try {
+    const sortByValue = req?.query?.sortBy ? req?.query?.sortBy : undefined;
+    const sortOrder = req?.query?.orderBy ? req?.query?.orderBy : 'asc';
     const jsrTags = await fetchJSRTags(req);
     const jsrfTags = await fetchJSRFTags(req);
+    if (sortByValue) {
+      const tags = [...jsrTags, ...jsrfTags];
+      return res.send(tags.sort(sortObjects(sortByValue, sortOrder)));
+    }
     res.send([...jsrTags, ...jsrfTags]);
   } catch(err) {
     LOGGER.error(`Could not fetch ALL GraffitiTags \n${err}`);

--- a/src/controllers/locationController.js
+++ b/src/controllers/locationController.js
@@ -1,6 +1,7 @@
 import { performJSRAction, performJSRFAction } from "../config/db.js";
 import { Actions } from "../config/dbActions.js";
 import LOGGER from "../utils/logger.js";
+import { sortObjects } from "../utils/utility.js";
 
 
 const Location = 'Location';
@@ -8,8 +9,14 @@ const Level = 'Level';
 
 export const getLocations = async (req, res) => {
   try {
+    const sortByValue = req?.query?.sortBy ? req?.query?.sortBy : undefined;
+    const sortOrder = req?.query?.orderBy ? req?.query?.orderBy : 'asc';
     const jsrLocations = await fetchJSRLocations(req);
     const jsrfLocations = await fetchJSRFLocations(req);
+    if (sortByValue) {
+      const locations = [...jsrLocations, ...jsrfLocations];
+      return res.send(locations.sort(sortObjects(sortByValue, sortOrder)));
+    }
     res.send([...jsrLocations, ...jsrfLocations]);
   } catch(err) {
     LOGGER.error(`Could not fetch ALL Locations \n${err}`);

--- a/src/controllers/songController.js
+++ b/src/controllers/songController.js
@@ -1,22 +1,21 @@
 import { performJSRAction, performJSRFAction } from "../config/db.js";
 import { Actions } from "../config/dbActions.js";
+import { sortObjects } from "../utils/utility.js";
 
 
 const Song = 'Song';
 
 export const getSongs = async (req, res) => {
   try {
-    const query = req?.query;
-    const songs = [];
-    const jsrSongs = await fetchJSRSongs(query);
-    const jsrfSongs = await fetchJSRFSongs(query);
-    if (jsrSongs && jsrSongs.length > 0) {
-      songs.push(jsrSongs);
+    const sortByValue = req?.query?.sortBy ? req?.query?.sortBy : undefined;
+    const sortOrder = req?.query?.orderBy ? req?.query?.orderBy : 'asc';
+    const jsrSongs = await fetchJSRSongs(req);
+    const jsrfSongs = await fetchJSRFSongs(req);
+    if (sortByValue) {
+      const songs = [...jsrSongs, ...jsrfSongs];
+      return res.send(songs.sort(sortObjects(sortByValue, sortOrder)));
     }
-    if (jsrfSongs && jsrfSongs.length > 0) {
-      songs.push(jsrfSongs);
-    }
-    res.send(songs.flat(1));
+    res.send([...jsrSongs, ...jsrfSongs]);
   } catch(err) {
     res.status(500).send(`Could not fetch ALL SONGS due to error: \n${err}`);
   }
@@ -24,7 +23,7 @@ export const getSongs = async (req, res) => {
 
 export const getJSRSongs = async (req, res) => {
   try {
-    const jsrSongs = await fetchJSRSongs(req?.query)
+    const jsrSongs = await fetchJSRSongs(req);
     if (jsrSongs) {
       return res.send(jsrSongs);
     }
@@ -36,7 +35,7 @@ export const getJSRSongs = async (req, res) => {
 
 export const getJSRSongById = async (req, res) => {
   try {
-    const jsrSong = await fetchJSRSongById(req?.params?.id);
+    const jsrSong = await performJSRAction(Actions.fetchById, Song, id);
     if (jsrSong) {
       return res.send(jsrSong);
     }
@@ -48,7 +47,7 @@ export const getJSRSongById = async (req, res) => {
 
 export const getJSRFSongs = async (req, res) => {
   try {
-    const jsrfSongs = await fetchJSRFSongs(req?.query);
+    const jsrfSongs = await fetchJSRFSongs(req);
     if (jsrfSongs) {
       return res.send(jsrfSongs);
     }
@@ -60,7 +59,7 @@ export const getJSRFSongs = async (req, res) => {
 
 export const getJSRFSongById = async (req, res) => {
   try {
-    const jsrfSong = await fetchJSRFSongById(req?.params?.id);
+    const jsrfSong = await performJSRFAction(Actions.fetchById, Song, id);
     if (jsrfSong) {
       return res.send(jsrfSong);
     }
@@ -70,24 +69,10 @@ export const getJSRFSongById = async (req, res) => {
   }
 }
 
-export const fetchJSRSongs = async (query) => {
-  if (query) {
-    return await performJSRAction(Actions.fetchWithQuery, Song, null, query);
-  }
-  return await performJSRAction(Actions.fetchAll, Song, null);
-}
-
-export const fetchJSRSongById = async (id) => {
-  return await performJSRAction(Actions.fetchById, Song, id);
+export const fetchJSRSongs = async (req) => {
+  return await performJSRAction(Actions.fetchWithQuery, Song, null, req?.query);
 }
   
-export const fetchJSRFSongs = async (query) => {
-  if (query) {
-    return await performJSRFAction(Actions.fetchWithQuery, Song, null, query);
-  }
-  return await performJSRFAction(Actions.fetchAll, Song, null);
-}
-
-export const fetchJSRFSongById = async (id) => {
-  return await performJSRFAction(Actions.fetchById, Song, id);
+export const fetchJSRFSongs = async (req) => {
+  return await performJSRFAction(Actions.fetchWithQuery, Song, null, req?.query);
 }

--- a/src/utils/utility.js
+++ b/src/utils/utility.js
@@ -1,0 +1,7 @@
+export const sortObjects = (property, order) => {
+  const sortOrder = order === 'desc' ? -1 : 1;
+  return function (a,b) {
+    var result = (a[property] < b[property]) ? -1 : (a[property] > b[property]) ? 1 : 0;
+    return result * sortOrder;
+  }
+}

--- a/test/characters.test.js
+++ b/test/characters.test.js
@@ -5,6 +5,7 @@ dotenv.config();
 
 import { connect, disconnect } from './helper/mongodbMemoryTest.js';
 import { fetchJSRCharacters, fetchJSRFCharacters } from '../src/controllers/characterController.js';
+import { sortObjects } from '../src/utils/utility.js';
 
 const baseUrl = `${process.env.BASE_URL}/v1/api`;
 const createMock = mockObj => axios.get = jest.fn().mockResolvedValue({ __esModule: true, data: mockObj })
@@ -30,6 +31,39 @@ describe('Character Routes', () => {
     expect(jsrCharacters[0]).toHaveProperty('descriptions')
     expect(jsrCharacters[0]).toHaveProperty('heroImage')
     expect(jsrCharacters[0]).toHaveProperty('wikiPage')
+  })
+
+  test('GET /characters?sortBy=name&orderBy=desc', async () => {
+    const req = {query: { sortBy: 'name', orderBy: 'desc' }};
+    const sortByValue = req?.query?.sortBy ? req?.query?.sortBy : undefined;
+    const sortOrder = req?.query?.orderBy ? req?.query?.orderBy : 'asc';
+    const jsrCharacters = await fetchJSRCharacters();
+    const jsrfCharacters = await fetchJSRFCharacters();
+
+    let characters = [];
+    if (sortByValue) {
+      const allCharacters = [...jsrCharacters, ...jsrfCharacters];
+      characters = allCharacters.sort(sortObjects(sortByValue, sortOrder));
+    } else {
+      characters = [...jsrCharacters, ...jsrfCharacters];
+    }
+    expect(isValidJson(characters)).toBe(true);
+  })
+
+  test('GET /characters/jsr?limit=5', async () => {
+    const req = {query: { limit: '5' }};
+    const jsrCharacters = await fetchJSRCharacters(req);
+    expect(Array.isArray(jsrCharacters)).toBe(true);
+    expect(isValidJson(jsrCharacters)).toBe(true);
+    expect(jsrCharacters).toHaveLength(5);
+  })
+
+  test('GET /characters/jsrf?limit=15', async () => {
+    const req = {query: { limit: '15' }};
+    const jsrCharacters = await fetchJSRCharacters(req);
+    expect(Array.isArray(jsrCharacters)).toBe(true);
+    expect(isValidJson(jsrCharacters)).toBe(true);
+    expect(jsrCharacters).toHaveLength(15);
   })
 
   /* Unit/Mock Tests */

--- a/test/graffitiTags.test.js
+++ b/test/graffitiTags.test.js
@@ -5,6 +5,7 @@ dotenv.config();
 
 import { connect, disconnect } from './helper/mongodbMemoryTest.js';
 import { fetchJSRTags, fetchJSRFTags } from '../src/controllers/graffitiTagController.js';
+import { sortObjects } from '../src/utils/utility.js';
 
 const baseUrl = `${process.env.BASE_URL}/v1/api`;
 const createMock = mockObj => axios.get = jest.fn().mockResolvedValue({ __esModule: true, data: mockObj })
@@ -34,6 +35,39 @@ describe('GraffitiTag Routes', () => {
     expect(jsrfTags[9]).toHaveProperty('gameId');
     expect(jsrfTags[9]).toHaveProperty('imageUrl');
     expect(jsrfTags[9]).toHaveProperty('wikiImageUrl');
+  })
+
+  test('GET /graffiti-tags?sortBy=name&orderBy=desc', async () => {
+    const req = {query: { sortBy: 'name', orderBy: 'desc' }};
+    const sortByValue = req?.query?.sortBy ? req?.query?.sortBy : undefined;
+    const sortOrder = req?.query?.orderBy ? req?.query?.orderBy : 'asc';
+    const jsrTags = await fetchJSRTags();
+    const jsrfTags = await fetchJSRFTags();
+
+    let tags = [];
+    if (sortByValue) {
+      const allTags = [...jsrTags, ...jsrfTags];
+      tags = allTags.sort(sortObjects(sortByValue, sortOrder));
+    } else {
+      tags = [...jsrTags, ...jsrfTags];
+    }
+    expect(isValidJson(tags)).toBe(true);
+  })
+
+  test('GET /graffiti-tags/jsr?limit=5', async () => {
+    const req = {query: { limit: '5' }};
+    const tags = await fetchJSRTags(req);
+    expect(Array.isArray(tags)).toBe(true);
+    expect(isValidJson(tags)).toBe(true);
+    expect(tags).toHaveLength(5);
+  })
+
+  test('GET /graffiti-tags/jsrf?limit=15', async () => {
+    const req = {query: { limit: '15' }};
+    const tags = await fetchJSRFTags(req);
+    expect(Array.isArray(tags)).toBe(true);
+    expect(isValidJson(tags)).toBe(true);
+    expect(tags).toHaveLength(15);
   })
 
   /* Unit/Mock Tests */

--- a/test/locations.test.js
+++ b/test/locations.test.js
@@ -5,6 +5,7 @@ dotenv.config();
 
 import { connect, disconnect } from './helper/mongodbMemoryTest.js';
 import { fetchJSRLocations, fetchJSRFLocations, fetchJSRLevels } from '../src/controllers/locationController.js';
+import { sortObjects } from '../src/utils/utility.js';
 
 const baseUrl = `${process.env.BASE_URL}/v1/api`;
 const createMock = mockObj => axios.get = jest.fn().mockResolvedValue({ __esModule: true, data: mockObj })
@@ -43,6 +44,39 @@ describe('Location Routes', () => {
     expect(levels[0]).toHaveProperty('location')
     expect(levels[0]).toHaveProperty('bossLevel')
     expect(levels[0]).toHaveProperty('chapter')
+  })
+
+  test('GET /locations?sortBy=name&orderBy=desc', async () => {
+    const req = {query: { sortBy: 'name', orderBy: 'desc' }};
+    const sortByValue = req?.query?.sortBy ? req?.query?.sortBy : undefined;
+    const sortOrder = req?.query?.orderBy ? req?.query?.orderBy : 'asc';
+    const jsrLocations = await fetchJSRLocations();
+    const jsrfLocations = await fetchJSRFLocations();
+
+    let locations = [];
+    if (sortByValue) {
+      const allLocations = [...jsrLocations, ...jsrfLocations];
+      locations = allLocations.sort(sortObjects(sortByValue, sortOrder));
+    } else {
+      tags = [...jsrLocations, ...jsrfLocations];
+    }
+    expect(isValidJson(locations)).toBe(true);
+  })
+
+  test('GET /locations/jsr?limit=2', async () => {
+    const req = {query: { limit: '2' }};
+    const locations = await fetchJSRLocations(req);
+    expect(Array.isArray(locations)).toBe(true);
+    expect(isValidJson(locations)).toBe(true);
+    expect(locations).toHaveLength(2);
+  })
+
+  test('GET /locations/jsrf?limit=15', async () => {
+    const req = {query: { limit: '15' }};
+    const locations = await fetchJSRFLocations(req);
+    expect(Array.isArray(locations)).toBe(true);
+    expect(isValidJson(locations)).toBe(true);
+    expect(locations).toHaveLength(15);
   })
 
   /* Unit/Mock Tests */

--- a/test/songs.test.js
+++ b/test/songs.test.js
@@ -5,10 +5,11 @@ dotenv.config();
 
 import { connect, disconnect } from './helper/mongodbMemoryTest.js';
 import { fetchJSRSongs, fetchJSRFSongs } from '../src/controllers/songController.js';
+import { sortObjects } from '../src/utils/utility.js';
+
 
 const baseUrl = `${process.env.BASE_URL}/v1/api`;
 const createMock = mockObj => axios.get = jest.fn().mockResolvedValue({ __esModule: true, data: mockObj })
-
 
 describe('Songs Routes', () => {
 
@@ -30,6 +31,39 @@ describe('Songs Routes', () => {
     expect(songs[0]).toHaveProperty('gameId');
     expect(songs[0]).toHaveProperty('name');
     expect(songs[0]).toHaveProperty('shortName');
+  })
+
+  test('GET /songs?sortBy=name&orderBy=desc', async () => {
+    const req = {query: { sortBy: 'name', orderBy: 'desc' }};
+    const sortByValue = req?.query?.sortBy ? req?.query?.sortBy : undefined;
+    const sortOrder = req?.query?.orderBy ? req?.query?.orderBy : 'asc';
+    const jsrSongs = await fetchJSRSongs();
+    const jsrfSongs = await fetchJSRFSongs();
+
+    let songs = [];
+    if (sortByValue) {
+      const allSongs = [...jsrSongs, ...jsrfSongs];
+      songs = allSongs.sort(sortObjects(sortByValue, sortOrder));
+    } else {
+      songs = [...jsrSongs, ...jsrfSongs];
+    }
+    expect(isValidJson(songs)).toBe(true);
+  })
+
+  test('GET /songs/jsr?limit=5', async () => {
+    const req = {query: { limit: '5' }};
+    const songs = await fetchJSRSongs(req);
+    expect(Array.isArray(songs)).toBe(true);
+    expect(isValidJson(songs)).toBe(true);
+    expect(songs).toHaveLength(5);
+  })
+
+  test('GET /songs/jsrf?limit=15', async () => {
+    const req = {query: { limit: '15' }};
+    const songs = await fetchJSRFSongs(req);
+    expect(Array.isArray(songs)).toBe(true);
+    expect(isValidJson(songs)).toBe(true);
+    expect(songs).toHaveLength(15);
   })
 
   /* Unit/Mock Tests */


### PR DESCRIPTION
## SORTING

 - You can pass a `sortBy` and/or `orderBy` query parameter to  sort results and order them. The default for orderBy is ASC.
 
 ## Limit
 - You can pass a `limit` query parameter to limit the number of results returned in the response.

 - You can pass all three of these query parameters and it will still work
 
 
 I also added in some integration tests to test the new query parameter and limit functionality.
 